### PR TITLE
Fix Cloudflare token variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ LE_EMAIL=robert@robertfisher.com
 CLOUDFLARE_DNS_API_TOKEN=cf_xxxxxxxxxxxxxxxxx  
 MYSQL_ROOT_PASSWORD=prod-secret                         # keep DB pwd out of repo
 ``` |
-| **GitHub → repo → Settings → Secrets** | same three vars above (`LE_EMAIL`, `CF_DNS_API_TOKEN`, `MYSQL_ROOT_PASSWORD`) |
+| **GitHub → repo → Settings → Secrets** | same three vars above (`LE_EMAIL`, `CLOUDFLARE_DNS_API_TOKEN`, `MYSQL_ROOT_PASSWORD`) |
 
 ### 2.2 CI/CD flow
 
@@ -56,6 +56,3 @@ MYSQL_ROOT_PASSWORD=prod-secret                         # keep DB pwd out of rep
    ```bash
    docker compose pull
    docker compose up -d
-# trigger
-# trigger
-# trigger


### PR DESCRIPTION
## Summary
- align docs with the variable name used by Docker Compose and the deploy workflow
- remove stray debug lines from README

## Testing
- `pnpm install` *(fails: npm registry blocked)*
- `pnpm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868200727148321984fa9c331f21a85