### PR TITLE
Fix CI/CD README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,6 @@ MYSQL_ROOT_PASSWORD=prod-secret                         # keep DB pwd out of rep
    ```bash
    docker compose pull
    docker compose up -d
+   ```
+
+   That's it—the droplet now runs the updated stack behind Traefik.


### PR DESCRIPTION
## Summary
- close the CI/CD code block in README
- explain the result of running `docker compose up -d`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682c8243a08321b144082579d7e892