### PR TITLE
Add onhostrule to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,6 +103,7 @@ jobs:
                   - "--certificatesresolvers.cf.acme.dnschallenge.provider=cloudflare"
                   - "--certificatesresolvers.cf.acme.email=${LE_EMAIL}"
                   - "--certificatesresolvers.cf.acme.storage=/letsencrypt/acme.json"
+                  - "--certificatesresolvers.cf.acme.onhostrule=true"
                 environment:
                   CLOUDFLARE_DNS_API_TOKEN: ${CLOUDFLARE_DNS_API_TOKEN}
                   LE_EMAIL: ${LE_EMAIL}


### PR DESCRIPTION
## Summary
- ensure Traefik uses `onhostrule=true` in deployment workflow

## Testing
- `docker compose config`

------
https://chatgpt.com/codex/tasks/task_e_686834acd4b88321b19b4172937bce9d