### PR TITLE
Slim runtime Dockerfile

### DIFF
--- a/nextjs-site/Dockerfile
+++ b/nextjs-site/Dockerfile
@@ -7,7 +7,7 @@ ENV NEXT_PUBLIC_WPGRAPHQL_URL=$NEXT_PUBLIC_WPGRAPHQL_URL
 
 # copy manifest first to leverage cache
 COPY package.json pnpm-lock.yaml ./
-RUN npm i -g pnpm && pnpm install --frozen-lockfile
+RUN npm i -g pnpm && pnpm install --frozen-lockfile --prod
 
 # copy source
 COPY . .
@@ -16,6 +16,12 @@ RUN pnpm build
 # ─────────────── Runtime stage ─────────────
 FROM node:22-slim
 WORKDIR /app
-COPY --from=builder /app ./
+ENV NODE_ENV=production
+
+# Copy only the built application and production dependencies
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+
 EXPOSE 3000
-CMD ["node", ".next/standalone/server.js"]
+CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary
- install production dependencies with `pnpm install --frozen-lockfile --prod`
- copy only built output and prod deps into runtime image

## Testing
- `docker build` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_686844fe395c8321888a7072b8efa0fc