### PR TITLE
Remove obsolete Traefik v3 flag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,7 +101,6 @@ jobs:
                   - "--certificatesresolvers.cf.acme.dnschallenge.provider=cloudflare"
                   - "--certificatesresolvers.cf.acme.email=${LE_EMAIL}"
                   - "--certificatesresolvers.cf.acme.storage=/letsencrypt/acme.json"
-                  - "--certificatesresolvers.cf.acme.onhostrule=true"
                 environment:
                   CLOUDFLARE_DNS_API_TOKEN: ${CLOUDFLARE_DNS_API_TOKEN}
                   LE_EMAIL: ${LE_EMAIL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,6 @@ services:
       - "--certificatesresolvers.cf.acme.dnschallenge.provider=cloudflare"
       - "--certificatesresolvers.cf.acme.email=${LE_EMAIL}"
       - "--certificatesresolvers.cf.acme.storage=/letsencrypt/acme.json"
-      - "--certificatesresolvers.cf.acme.onhostrule=true"
     environment:
       CLOUDFLARE_DNS_API_TOKEN: ${CLOUDFLARE_DNS_API_TOKEN}
       LE_EMAIL: ${LE_EMAIL}


### PR DESCRIPTION
## Summary
- remove deprecated `onhostrule` option from Traefik configuration

## Testing
- `pnpm lint`
- `composer install` *(fails: curl error downloading from downloads.wordpress.org)*

------
https://chatgpt.com/codex/tasks/task_e_686853c62d508321a3906fdc2b02f86f