### PR TITLE
Update WPGraphQL URL in build args

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,9 @@ jobs:
       # 4 ─ Next.js image
       - name: Build & push Next.js
         run: |
-          docker build -t ghcr.io/${{ github.repository }}/next:${{ github.sha }} nextjs-site
+          docker build \
+            --build-arg NEXT_PUBLIC_WPGRAPHQL_URL=http://wordpress/graphql \
+            -t ghcr.io/${{ github.repository }}/next:${{ github.sha }} nextjs-site
           docker push     ghcr.io/${{ github.repository }}/next:${{ github.sha }}
 
       # 5 ─ Deploy on droplet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     build:
       context: ./nextjs-site
       args:
-        NEXT_PUBLIC_WPGRAPHQL_URL: http://placeholder/graphql
+        NEXT_PUBLIC_WPGRAPHQL_URL: http://wordpress/graphql
     restart: unless-stopped
     expose: ["3000"]
     environment:


### PR DESCRIPTION
## Summary
- point `docker-compose` Next.js build arg to the local WordPress container
- pass the same build arg when building the Next.js image in the deploy workflow

## Testing
- `pnpm lint`
- `composer install` *(fails: CONNECT tunnel failed)*
- `composer lint` *(fails: pint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68685c2129808321803297d8bce87529