### PR TITLE
Add wp-graphql dependency

### DIFF
--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -39,7 +39,8 @@
     "roots/bedrock-disallow-indexing": "^2.0",
     "roots/wordpress": "6.8.1",
     "roots/wp-config": "1.0.0",
-    "wpackagist-theme/twentytwentyfive": "^1.0"
+    "wpackagist-theme/twentytwentyfive": "^1.0",
+    "wpackagist-plugin/wp-graphql": "^1.0"
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest",


### PR DESCRIPTION
## Summary
- include `wpackagist-plugin/wp-graphql` in WordPress dependencies

## Testing
- `pnpm lint`
- `composer lint` *(fails: `pint` not found)*
- `composer update wpackagist-plugin/wp-graphql` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68685c23db588321885cfc1dc1f3f488