### PR TITLE
Fix trailing characters in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,3 @@ uploads/
 
 # Composer & WP uploads
 wordpress/vendor/
-
-
-#


### PR DESCRIPTION
## Summary
- tidy up root .gitignore

## Testing
- `pnpm lint`
- `composer lint` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68686b55a1988321a631134bc8d98425