### PR TITLE
Add root .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Root Docker ignore
+
+# Never send VCS history
+.git
+.gitignore
+
+# Ignore entire WordPress backend
+wordpress/
+
+# Dependencies
+node_modules/
+.pnpm/
+nextjs-site/node_modules/
+nextjs-site/.pnpm/
+
+# Build output
+nextjs-site/.next/
+nextjs-site/out/
+nextjs-site/build/
+nextjs-site/coverage/
+
+# Docker volumes and runtime artefacts
+uploads/
+db_data/
+
+# Logs and temp files
+*.log
+*.tmp
+tmp/
+
+# Environment files
+.env
+.env.*
+wordpress/.env
+
+# IDE/editor folders
+.vscode/
+.idea/
+.DS_Store


### PR DESCRIPTION
## Summary
- create `.dockerignore` at repo root to avoid sending unnecessary files during Docker builds

## Testing
- `pnpm lint` in `nextjs-site`
- `composer lint` *(fails: pint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68785964ec688321a03bec576e0eadac