### PR TITLE
Add lint jobs to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,27 @@ permissions:
   packages: write
 
 jobs:
+  lint-nextjs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run pnpm lint
+        working-directory: nextjs-site
+        run: |
+          corepack enable pnpm
+          pnpm lint
+
+  lint-wordpress:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run composer lint
+        working-directory: wordpress
+        run: composer lint
+
   deploy:
     runs-on: ubuntu-latest
+    needs: [lint-nextjs, lint-wordpress]
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- run `pnpm lint` in `nextjs-site`
- run `composer lint` in `wordpress`
- deploy waits for both lint jobs

## Testing
- `pnpm lint` *(passes)*
- `composer lint` *(fails: pint not found due to blocked downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68785967622c832194d5c5a2515d3927