### PR TITLE
Fix TypeScript props for slug page

### DIFF
--- a/nextjs-site/src/app/[slug]/page.tsx
+++ b/nextjs-site/src/app/[slug]/page.tsx
@@ -4,10 +4,11 @@ import { gql } from "@apollo/client";
 export const dynamic = "force-dynamic";
 
 interface PageProps {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }
 
 export default async function WPPage({ params }: PageProps) {
+  const { slug } = await params;
   try {
     const { data } = await client.query({
       query: gql`
@@ -18,7 +19,7 @@ export default async function WPPage({ params }: PageProps) {
           }
         }
       `,
-      variables: { slug: params.slug },
+      variables: { slug },
       fetchPolicy: "no-cache",
     });
 


### PR DESCRIPTION
## Summary
- adjust `[slug]` page to match Next.js typed route expectations

## Testing
- `pnpm lint`
- `pnpm build`
- `composer lint` *(fails: pint not found)*

------
https://chatgpt.com/codex/tasks/task_e_687936b873c0832181429ecd372acf97