### PR TITLE
Update lint jobs to install dependencies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        working-directory: nextjs-site
+        run: |
+          corepack enable pnpm
+          pnpm install --frozen-lockfile
       - name: Run pnpm lint
         working-directory: nextjs-site
         run: |
@@ -24,6 +33,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up PHP
+        uses: actions/setup-php@v3
+        with:
+          php-version: '8.1'
+      - name: Install dependencies
+        working-directory: wordpress
+        run: composer install --no-interaction
       - name: Run composer lint
         working-directory: wordpress
         run: composer lint


### PR DESCRIPTION
## Summary
- set up Node and install pnpm deps before linting Next.js
- set up PHP and install composer deps before linting WordPress

## Testing
- `pnpm lint`
- `composer install` *(fails: CONNECT tunnel failed)*
- `composer lint` *(fails: pint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687955f745d0832180b8e27c7ee913dc