### PR TITLE
Pin Pint to PHP 8.1-compatible release

### DIFF
--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -52,7 +52,7 @@
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest",
-    "laravel/pint": "^1.18"
+    "laravel/pint": "~1.20.0"
   },
   "config": {
     "optimize-autoloader": true,

--- a/wordpress/composer.lock
+++ b/wordpress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e37362026e38ca5ff18f430c54763091",
+    "content-hash": "69befb030d0fe83a737993c6c2d1805e",
     "packages": [
         {
             "name": "composer/installers",
@@ -1069,16 +1069,16 @@
     "packages-dev": [
         {
             "name": "laravel/pint",
-            "version": "v1.24.0",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "0345f3b05f136801af8c339f9d16ef29e6b4df8a"
+                "reference": "53072e8ea22213a7ed168a8a15b96fbb8b82d44b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/0345f3b05f136801af8c339f9d16ef29e6b4df8a",
-                "reference": "0345f3b05f136801af8c339f9d16ef29e6b4df8a",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/53072e8ea22213a7ed168a8a15b96fbb8b82d44b",
+                "reference": "53072e8ea22213a7ed168a8a15b96fbb8b82d44b",
                 "shasum": ""
             },
             "require": {
@@ -1086,15 +1086,15 @@
                 "ext-mbstring": "*",
                 "ext-tokenizer": "*",
                 "ext-xml": "*",
-                "php": "^8.2.0"
+                "php": "^8.1.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.82.2",
-                "illuminate/view": "^11.45.1",
-                "larastan/larastan": "^3.5.0",
-                "laravel-zero/framework": "^11.45.0",
+                "friendsofphp/php-cs-fixer": "^3.66.0",
+                "illuminate/view": "^10.48.25",
+                "larastan/larastan": "^2.9.12",
+                "laravel-zero/framework": "^10.48.25",
                 "mockery/mockery": "^1.6.12",
-                "nunomaduro/termwind": "^2.3.1",
+                "nunomaduro/termwind": "^1.17.0",
                 "pestphp/pest": "^2.36.0"
             },
             "bin": [
@@ -1102,9 +1102,6 @@
             ],
             "type": "project",
             "autoload": {
-                "files": [
-                    "overrides/Runner/Parallel/ProcessFactory.php"
-                ],
                 "psr-4": {
                     "App\\": "app/",
                     "Database\\Seeders\\": "database/seeders/",
@@ -1134,7 +1131,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2025-07-10T18:09:32+00:00"
+            "time": "2025-01-14T16:20:53+00:00"
         },
         {
             "name": "roave/security-advisories",

--- a/wordpress/config/application.php
+++ b/wordpress/config/application.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Your base production configuration goes in this file. Environment‑specific
  * overrides go in their respective config/environments/{{WP_ENV}}.php file.
@@ -8,6 +9,7 @@
  */
 
 use Roots\WPConfig\Config;
+
 use function Env\env;
 
 // Tell vlucas/php‑dotenv to treat ENV as arrays, convert types, and strip quotes
@@ -57,7 +59,7 @@ if (!env('WP_ENVIRONMENT_TYPE') && in_array(WP_ENV, ['production', 'staging', 'd
     Config::define('WP_ENVIRONMENT_TYPE', WP_ENV);
 }
 
-Config::define('WP_HOME',    env('WP_HOME'));
+Config::define('WP_HOME', env('WP_HOME'));
 Config::define('WP_SITEURL', env('WP_SITEURL'));
 
 /**
@@ -65,9 +67,9 @@ Config::define('WP_SITEURL', env('WP_SITEURL'));
  * Custom content directory (Bedrock convention: /web/app)
  * -----------------------------------------------------------------
  */
-Config::define('CONTENT_DIR',      '/app');
-Config::define('WP_CONTENT_DIR',   $webroot_dir . Config::get('CONTENT_DIR'));
-Config::define('WP_CONTENT_URL',   Config::get('WP_HOME') . Config::get('CONTENT_DIR'));
+Config::define('CONTENT_DIR', '/app');
+Config::define('WP_CONTENT_DIR', $webroot_dir . Config::get('CONTENT_DIR'));
+Config::define('WP_CONTENT_URL', Config::get('WP_HOME') . Config::get('CONTENT_DIR'));
 
 /**
  * -----------------------------------------------------------------
@@ -88,10 +90,10 @@ $table_prefix = env('DB_PREFIX') ?: 'wp_';
 
 if (env('DATABASE_URL')) {
     $dsn = (object) parse_url(env('DATABASE_URL'));
-    Config::define('DB_NAME',     substr($dsn->path, 1));
-    Config::define('DB_USER',     $dsn->user);
+    Config::define('DB_NAME', substr($dsn->path, 1));
+    Config::define('DB_USER', $dsn->user);
     Config::define('DB_PASSWORD', $dsn->pass ?? null);
-    Config::define('DB_HOST',     isset($dsn->port) ? "{$dsn->host}:{$dsn->port}" : $dsn->host);
+    Config::define('DB_HOST', isset($dsn->port) ? "{$dsn->host}:{$dsn->port}" : $dsn->host);
 }
 
 /**
@@ -99,22 +101,22 @@ if (env('DATABASE_URL')) {
  * Authentication keys & salts
  * -----------------------------------------------------------------
  */
-Config::define('AUTH_KEY',          env('AUTH_KEY'));
-Config::define('SECURE_AUTH_KEY',   env('SECURE_AUTH_KEY'));
-Config::define('LOGGED_IN_KEY',     env('LOGGED_IN_KEY'));
-Config::define('NONCE_KEY',         env('NONCE_KEY'));
-Config::define('AUTH_SALT',         env('AUTH_SALT'));
-Config::define('SECURE_AUTH_SALT',  env('SECURE_AUTH_SALT'));
-Config::define('LOGGED_IN_SALT',    env('LOGGED_IN_SALT'));
-Config::define('NONCE_SALT',        env('NONCE_SALT'));
+Config::define('AUTH_KEY', env('AUTH_KEY'));
+Config::define('SECURE_AUTH_KEY', env('SECURE_AUTH_KEY'));
+Config::define('LOGGED_IN_KEY', env('LOGGED_IN_KEY'));
+Config::define('NONCE_KEY', env('NONCE_KEY'));
+Config::define('AUTH_SALT', env('AUTH_SALT'));
+Config::define('SECURE_AUTH_SALT', env('SECURE_AUTH_SALT'));
+Config::define('LOGGED_IN_SALT', env('LOGGED_IN_SALT'));
+Config::define('NONCE_SALT', env('NONCE_SALT'));
 
 /**
  * -----------------------------------------------------------------
  * Custom settings
  * -----------------------------------------------------------------
  */
-Config::define('AUTOMATIC_UPDATER_DISABLED', true);                     // core updates come via Docker
-Config::define('DISABLE_WP_CRON',         env('DISABLE_WP_CRON') ?: false);
+Config::define('AUTOMATIC_UPDATER_DISABLED', true); // core updates come via Docker
+Config::define('DISABLE_WP_CRON', env('DISABLE_WP_CRON') ?: false);
 
 /** ───── FILESYSTEM ───────────────────────────────────────────────
  *  Allow WordPress & WP‑CLI to write directly inside the container
@@ -127,13 +129,13 @@ Config::define('WP_DEFAULT_THEME', 'hello-elementor');
 /**
  * Security‑hardening helpers
  */
-Config::define('DISALLOW_FILE_EDIT',  true);   // no Appearance → Editor
-Config::define('DISALLOW_FILE_MODS',  true);   // themes/plugins only via CI
+Config::define('DISALLOW_FILE_EDIT', true);   // no Appearance → Editor
+Config::define('DISALLOW_FILE_MODS', true);   // themes/plugins only via CI
 
 /**
  * Performance / housekeeping
  */
-Config::define('WP_POST_REVISIONS',   env('WP_POST_REVISIONS') ?? true);
+Config::define('WP_POST_REVISIONS', env('WP_POST_REVISIONS') ?? true);
 Config::define('CONCATENATE_SCRIPTS', false);
 
 /**
@@ -142,8 +144,8 @@ Config::define('CONCATENATE_SCRIPTS', false);
  * -----------------------------------------------------------------
  */
 Config::define('WP_DEBUG_DISPLAY', false);
-Config::define('WP_DEBUG_LOG',     false);
-Config::define('SCRIPT_DEBUG',     false);
+Config::define('WP_DEBUG_LOG', false);
+Config::define('SCRIPT_DEBUG', false);
 ini_set('display_errors', '0');
 
 /**

--- a/wordpress/web/app/mu-plugins/disable-file-mods.php
+++ b/wordpress/web/app/mu-plugins/disable-file-mods.php
@@ -1,10 +1,10 @@
 <?php
+
 /**
  * Suppress the “some core files are not writable” Site‑Health test.
  * The stack is immutable (Docker image); WP should never edit core.
  */
-add_filter( 'site_status_tests', function ( $tests ) {
-    unset( $tests['async']['wordpress_filesystem'] );
+add_filter('site_status_tests', function ($tests) {
+    unset($tests['async']['wordpress_filesystem']);
     return $tests;
-} );
- 
+});

--- a/wordpress/web/app/mu-plugins/disable-site-health-noise.php
+++ b/wordpress/web/app/mu-plugins/disable-site-health-noise.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Bedrock / Docker: hide Site‑Health items that are irrelevant in an
  * immutable, image‑based deployment.
@@ -10,7 +11,7 @@
  * - page_cache            → handled by WP Super Cache + Cloudflare
  */
 
-add_filter( 'site_status_tests', function ( $tests ) {
+add_filter('site_status_tests', function ($tests) {
 
     $disabled = [
         'background_updates',   // $tests['direct']
@@ -19,12 +20,13 @@ add_filter( 'site_status_tests', function ( $tests ) {
         'page_cache',           // $tests['async']
     ];
 
-    foreach ( $tests as $group => $group_tests ) {
-        foreach ( $group_tests as $slug => $test ) {
-            if ( in_array( $slug, $disabled, true ) ) {
-                unset( $tests[ $group ][ $slug ] );
+    foreach ($tests as $group => $group_tests) {
+        foreach ($group_tests as $slug => $test) {
+            if (in_array($slug, $disabled, true)) {
+                unset($tests[$group][$slug]);
             }
         }
     }
+
     return $tests;
-} );
+});

--- a/wordpress/web/app/mu-plugins/ignore-readonly-core.php
+++ b/wordpress/web/app/mu-plugins/ignore-readonly-core.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * mu-plugins/ignore-readonly-core.php
  * Silences Site Health alerts about read‑only core files in Docker.


### PR DESCRIPTION
## Summary
- require `laravel/pint` `~1.20.0` to ensure compatibility with PHP 8.1
- regenerate `composer.lock`
- fix Pint style issues in WordPress configuration files

## Testing
- `composer lint`
- `composer install --dry-run`
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa4c227408321ba8b882f3289482b