### PR TITLE
Fix WP-CLI rewrite filter formatting

### DIFF
--- a/wordpress/web/app/mu-plugins/wp-cli-htaccess-fix.php
+++ b/wordpress/web/app/mu-plugins/wp-cli-htaccess-fix.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
- * Force `got_rewrite` to `true` when WP‑CLI runs so that
- * `wp rewrite flush --hard` always recreates /web/.htaccess
- * inside the container.
+ * Force `got_rewrite` to `true` when WP‑CLI runs
+ * so `wp rewrite flush --hard` always recreates /web/.htaccess.
  */
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	add_filter( 'got_rewrite', static fn () => true, 99 );
+if (defined('WP_CLI') && WP_CLI) {
+    add_filter('got_rewrite', static fn() => true, 99);
 }


### PR DESCRIPTION
## Summary
- restore and format the WP‑CLI `.htaccess` mu-plugin
- keep spacing PSR‑12 compliant

## Testing
- `composer lint`

------
https://chatgpt.com/codex/tasks/task_e_687bb25019c48321ac5fddc628e8ee2e