### PR TITLE
Fix env file creation in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,14 +160,12 @@ jobs:
             le:
           COMPOSE
 
-          cp .env.example .env
           cat > .env <<ENV
           CLOUDFLARE_DNS_API_TOKEN=${{ secrets.CLOUDFLARE_DNS_API_TOKEN }}
           LE_EMAIL=${{ secrets.LE_EMAIL }}
           MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}
           ENV
 
-          cp stack.env.example stack.env
           cat > stack.env <<'STACK'
           AUTH_KEY=${{ secrets.AUTH_KEY }}
           SECURE_AUTH_KEY=${{ secrets.SECURE_AUTH_KEY }}


### PR DESCRIPTION
## Summary
- remove attempts to copy `.env.example` and `stack.env.example` on the droplet
- create env files directly from GitHub secrets during deployment

## Testing
- `pnpm lint` in `nextjs-site`
- `composer lint` in `wordpress`


------
https://chatgpt.com/codex/tasks/task_e_687bb5dc47c083219a3eccd59d591bed