### PR TITLE
Add site info script

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,8 @@ chmod 600 /var/lib/docker/volumes/consulting-wp-next_le/_data/acme.json
 * `docker compose logs traefik`
 * check permissions of `acme.json` (should be `600`)
 * ensure required environment variables (`LE_EMAIL`, `CLOUDFLARE_DNS_API_TOKEN`, `MYSQL_ROOT_PASSWORD`) are set
+
+## 3 Site info
+
+Run `node ./scripts/site-info.js` to print a JSON summary of the stack. This shows
+current URLs, versions and the Traefik routing configuration.

--- a/scripts/site-info.js
+++ b/scripts/site-info.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+function readJSON(p) {
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function getComposerPackage(lock, name) {
+  return lock.packages.find(pkg => pkg.name === name);
+}
+
+const lockPath = path.join(__dirname, '..', 'wordpress', 'composer.lock');
+const composerLock = readJSON(lockPath);
+
+const wp = getComposerPackage(composerLock, 'roots/wordpress');
+const wpGraphql = getComposerPackage(composerLock, 'wpackagist-plugin/wp-graphql');
+
+const nextPkg = readJSON(path.join(__dirname, '..', 'nextjs-site', 'package.json'));
+
+const info = {
+  siteName: 'robertfisher.com',
+  urls: {
+    local: {
+      next: 'http://localhost',
+      wpAdmin: 'http://localhost:8080/wp/wp-admin',
+      graphql: 'http://localhost/graphql'
+    },
+    production: {
+      next: 'https://robertfisher.com',
+      nextWWW: 'https://www.robertfisher.com',
+      wordpress: 'https://wp.robertfisher.com'
+    }
+  },
+  versions: {
+    wordpress: wp ? wp.version : null,
+    plugins: {
+      'wp-graphql': wpGraphql ? wpGraphql.version : null
+    },
+    nextjs: nextPkg.dependencies.next,
+    traefik: '3',
+    mariadb: '11'
+  },
+  routes: {
+    wordpress: {
+      production: 'wp.robertfisher.com',
+      local: [
+        'localhost/wp',
+        'localhost/graphql',
+        'localhost:8080/wp/wp-admin'
+      ]
+    },
+    next: {
+      production: ['robertfisher.com', 'www.robertfisher.com'],
+      local: 'localhost'
+    }
+  }
+};
+
+console.log(JSON.stringify(info, null, 2));


### PR DESCRIPTION
## Summary
- add a `site-info.js` helper in `scripts/`
- document the helper in a new README section
- keep existing lints happy

## Testing
- `pnpm lint`
- `composer lint`


------
https://chatgpt.com/codex/tasks/task_e_687bcc84a2048321bd54465747f30956