### PR TITLE
Fix database healthcheck quoting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,7 +102,7 @@ jobs:
                 volumes: [ "db_data:/var/lib/mysql" ]
                 healthcheck:
                   test: ["CMD-SHELL",
-                         "mysqladmin ping -h127.0.0.1 -uroot -p${MYSQL_ROOT_PASSWORD} --silent"]
+                         "mysqladmin ping -h127.0.0.1 -uroot -p$MYSQL_ROOT_PASSWORD --silent"]
                   interval: 5s
                   timeout: 3s
                   retries: 30


### PR DESCRIPTION
## Summary
- avoid host shell variable substitution for `MYSQL_ROOT_PASSWORD`

## Testing
- `pnpm lint`
- `composer lint`

------
https://chatgpt.com/codex/tasks/task_e_687d1ec078ac8321a3fea303de005ef0