### PR TITLE
Allow GraphQL endpoint without trailing slash

### DIFF
--- a/wordpress/web/app/mu-plugins/disable-graphql-canonical.php
+++ b/wordpress/web/app/mu-plugins/disable-graphql-canonical.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Allow the GraphQL endpoint without a trailing slash.
+ * Prevents WordPress from redirecting /graphql to /graphql/.
+ */
+add_filter('redirect_canonical', static function ($canonical_url, $requested_url) {
+    if (function_exists('is_graphql_http_request') && is_graphql_http_request()) {
+        return false;
+    }
+    return $canonical_url;
+}, 10, 2);


### PR DESCRIPTION
## Summary
- add MU-plugin to bypass `redirect_canonical` for GraphQL requests

## Testing
- `composer lint`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_687d64c00874832188792d4a2a30de5d