### PR TITLE
Allow GraphQL endpoint without trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ docker compose up -d            # fresh DB, run installer
 * `https://localhost:8080/wp/wp-admin/install.php` shows **“Welcome to WordPress – Site Title / Username / Password”**
 * After setup → activate **WP GraphQL** → save **Permalinks / Post name**
 * `http://localhost:8080/graphql` returns `{"errors":[{"message":"Must provide query string"}]}`
+  (no redirect to `/graphql/`; if you see a 301, flush permalinks and verify
+  `web/app/mu-plugins/disable-graphql-canonical.php` is present)
 * `http://localhost:3100` renders the Next.js front‑end (or use Turbopack on :3000).
 
 ---

--- a/wordpress/web/app/mu-plugins/disable-graphql-canonical.php
+++ b/wordpress/web/app/mu-plugins/disable-graphql-canonical.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Allow the GraphQL endpoint without a trailing slash.
+ * Prevents WordPress from redirecting /graphql to /graphql/.
+ */
+add_filter('redirect_canonical', static function ($canonical_url, $requested_url) {
+    if (function_exists('is_graphql_http_request') && is_graphql_http_request()) {
+        return false;
+    }
+    return $canonical_url;
+}, 10, 2);


### PR DESCRIPTION
## Summary
- add MU-plugin to bypass `redirect_canonical` for GraphQL requests
- mention how to troubleshoot GraphQL redirect in README

## Testing
- `pnpm lint`
- `composer lint`


------
https://chatgpt.com/codex/tasks/task_e_687d64c00874832188792d4a2a30de5d