### PR TITLE
Fix PHP lint errors

### DIFF
--- a/wordpress/web/app/mu-plugins/disable-graphql-canonical.php
+++ b/wordpress/web/app/mu-plugins/disable-graphql-canonical.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Disable WordPress core canonical redirect on the `/graphql` endpoint.
  *
@@ -24,5 +25,5 @@ add_filter(
         return $redirect_url; // default behaviour elsewhere
     },
     5, // run *before* WP core’s canonical check (priority 10)
-    2
+    2,
 );


### PR DESCRIPTION
## Summary
- add missing blank line after the opening tag
- add trailing comma in `add_filter` call to satisfy Pint rules

## Testing
- `composer lint`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_687d9336d97883218679b05678227988