### PR TITLE
Add Next.js env example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ tmp/
 # ────────────────────────── Environment files ───────────────────────
 .env
 .env.*
+!nextjs-site/.env.example
 wordpress/.env        # if someone creates a runtime .env inside WP
 stack.env
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,15 @@
 ## 1 Local workflow
 
 1. Copy `.env.example` → `.env` and `stack.env.example` → `stack.env`, then fill in the placeholder values.
-2. Install dependencies **before** running Docker:
+2. Copy `nextjs-site/.env.example` → `nextjs-site/.env.local` before running `pnpm dev`.
+3. Install dependencies **before** running Docker:
 
 ```bash
    cd nextjs-site && pnpm install
 cd wordpress   && composer install
 ```
 
-3. After installing dependencies, run `pnpm lint` from `nextjs-site` and `composer lint` from `wordpress`. Both must pass before opening a pull request. If `pnpm lint` complains that `next` is missing, simply run `pnpm install` in `nextjs-site/` first.
+4. After installing dependencies, run `pnpm lint` from `nextjs-site` and `composer lint` from `wordpress`. Both must pass before opening a pull request. If `pnpm lint` complains that `next` is missing, simply run `pnpm install` in `nextjs-site/` first.
 
 | Goal | One‑liner | Opens in browser |
 |------|-----------|------------------|

--- a/nextjs-site/.env.example
+++ b/nextjs-site/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_WPGRAPHQL_URL=http://localhost:8080/graphql
+

--- a/nextjs-site/.gitignore
+++ b/nextjs-site/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary
- add `.env.example` for Next.js
- explain copying `.env.example` to `.env.local`
- unignore env example

## Testing
- `pnpm lint`
- `composer lint`


------
https://chatgpt.com/codex/tasks/task_e_687da02d55588321816cf9a66100c8e3