### PR TITLE
Make domain configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 LE_EMAIL=you@example.com
 CLOUDFLARE_DNS_API_TOKEN=cf_example_token
 
+# ─────── Domain for production deployments ─────────
+DOMAIN=example.com
+
 # ─────── MariaDB root password (local & CI) ────────────────────────────
 MYSQL_ROOT_PASSWORD=local-db-password
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build & push Next.js
         run: |
           docker build \
-            --build-arg NEXT_PUBLIC_WPGRAPHQL_URL=https://wp.robertfisher.com/graphql \
+            --build-arg NEXT_PUBLIC_WPGRAPHQL_URL=https://wp.${{ secrets.DOMAIN }}/graphql \
             -t ghcr.io/${{ github.repository }}/next:${{ github.sha }} nextjs-site
           docker push ghcr.io/${{ github.repository }}/next:${{ github.sha }}
 
@@ -117,13 +117,13 @@ jobs:
                   DB_PASSWORD:   ${MYSQL_ROOT_PASSWORD}
                   DB_HOST:       db
                   WP_ENV:        production
-                  WP_HOME:       https://wp.robertfisher.com
-                  WP_SITEURL:    https://wp.robertfisher.com/wp
+                  WP_HOME:       https://wp.${{ secrets.DOMAIN }}
+                  WP_SITEURL:    https://wp.${{ secrets.DOMAIN }}/wp
                 expose: ["80"]
                 volumes: [ "uploads:/var/www/html/web/app/uploads" ]
                 labels:
                   - traefik.enable=true
-                  - traefik.http.routers.wp.rule=Host(`wp.robertfisher.com`)
+                  - traefik.http.routers.wp.rule=Host(`wp.${{ secrets.DOMAIN }}`)
                   - traefik.http.routers.wp.entrypoints=websecure
                   - traefik.http.routers.wp.tls.certresolver=cf
                   - traefik.http.services.wp.loadbalancer.server.port=80
@@ -135,11 +135,11 @@ jobs:
                 image: ghcr.io/${{ github.repository }}/next:${{ github.sha }}
                 restart: unless-stopped
                 environment:
-                  NEXT_PUBLIC_WPGRAPHQL_URL: https://wp.robertfisher.com/graphql
+                  NEXT_PUBLIC_WPGRAPHQL_URL: https://wp.${{ secrets.DOMAIN }}/graphql
                 expose: ["3000"]
                 labels:
                   - traefik.enable=true
-                  - traefik.http.routers.next.rule=Host(`robertfisher.com`) || Host(`www.robertfisher.com`)
+                  - traefik.http.routers.next.rule=Host(`${{ secrets.DOMAIN }}`) || Host(`www.${{ secrets.DOMAIN }}`)
                   - traefik.http.routers.next.entrypoints=websecure
                   - traefik.http.routers.next.tls.certresolver=cf
                   - traefik.http.services.next.loadbalancer.server.port=3000
@@ -203,7 +203,7 @@ jobs:
             docker compose exec wordpress bash -c '
               cd /var/www/html/web &&
               wp core is-installed --allow-root || wp core install \
-                  --url=https://wp.robertfisher.com \
+                  --url=https://wp.${{ secrets.DOMAIN }} \
                   --title="Production Site" \
                   --admin_user=${WP_ADMIN_USER:-admin} \
                   --admin_password=${WP_ADMIN_PASS:-changeme} \
@@ -222,7 +222,7 @@ jobs:
             /srv/consultancy/bin/wp-bootstrap.sh
 
             ## ───── GraphQL smoke‑test ─────
-            curl -fsSL https://wp.robertfisher.com/graphql?query=%7B__typename%7D \
+            curl -fsSL https://wp.${{ secrets.DOMAIN }}/graphql?query=%7B__typename%7D \
               || { echo "❌ GraphQL endpoint unreachable"; exit 1; }
 
     # —— WordPress housekeeping ——————————————————————————

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🐳 Bedrock + Next starter — <https://robertfisher.com>
+# 🐳 Bedrock + Next starter — <https://example.com>
 
 * **WordPress** (Roots / Bedrock) — headless CMS  
 * **Next.js 15** (React 19 ready) — front‑end  
@@ -50,14 +50,15 @@ docker compose up -d            # fresh DB, run installer
 
 | Where | What |
 |-------|------|
-| **Cloudflare** | *A* record → droplet IP (for `robertfisher.com`, `www`, `wp`) |
+| **Cloudflare** | *A* record → droplet IP (for your domain, `www`, `wp`) |
 | **Cloudflare → API Tokens** | create token → *Edit zone DNS* (for that zone) |
 | **Droplet** (`/etc/environment`) | ```bash
-LE_EMAIL=robert@robertfisher.com
+LE_EMAIL=you@example.com
 CLOUDFLARE_DNS_API_TOKEN=cf_xxxxxxxxxxxxxxxxx
 MYSQL_ROOT_PASSWORD=prod-secret                         # keep DB pwd out of repo
+DOMAIN=example.com
 ``` |
-| **GitHub → repo → Settings → Secrets** | same three vars above (`LE_EMAIL`, `CLOUDFLARE_DNS_API_TOKEN`, `MYSQL_ROOT_PASSWORD`) |
+| **GitHub → repo → Settings → Secrets** | same vars + `DOMAIN` |
 
 #### Traefik `le` volume
 

--- a/bin/wp-bootstrap.sh
+++ b/bin/wp-bootstrap.sh
@@ -3,7 +3,7 @@ set -eu
 docker compose exec wordpress bash -c '
   cd /var/www/html/web &&
   wp core is-installed --allow-root || wp core install \
-      --url=https://wp.robertfisher.com \
+      --url=https://wp.${DOMAIN:-example.com} \
       --title="Production Site" \
       --admin_user=${WP_ADMIN_USER:-admin} \
       --admin_password=${WP_ADMIN_PASS:-changeme} \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - uploads:/var/www/html/web/app/uploads
     labels:
       - traefik.enable=true
-      - traefik.http.routers.wp.rule=Host(`wp.robertfisher.com`)
+      - traefik.http.routers.wp.rule=Host(`wp.${DOMAIN:-example.com}`)
       - traefik.http.routers.wp.entrypoints=websecure
       - traefik.http.routers.wp.tls.certresolver=cf
       - traefik.http.services.wp.loadbalancer.server.port=80
@@ -61,7 +61,7 @@ services:
       NEXT_PUBLIC_WPGRAPHQL_URL: http://wordpress/graphql
     labels:
       - traefik.enable=true
-      - traefik.http.routers.next.rule=Host(`robertfisher.com`) || Host(`www.robertfisher.com`)
+      - traefik.http.routers.next.rule=Host(`${DOMAIN:-example.com}`) || Host(`www.${DOMAIN:-example.com}`)
       - traefik.http.routers.next.entrypoints=websecure
       - traefik.http.routers.next.tls.certresolver=cf
       - traefik.http.services.next.loadbalancer.server.port=3000

--- a/nextjs-site/README.md
+++ b/nextjs-site/README.md
@@ -2,8 +2,8 @@
 
 | Layer | Tech | URL (prod) |
 |-------|------|------------|
-| CMS & API | WordPress (Bedrock) + WPGraphQL | https://wp.robertfisher.com |
-| Front‑end | Next.js 15 / App Router | https://robertfisher.com |
+| CMS & API | WordPress (Bedrock) + WPGraphQL | https://wp.example.com |
+| Front‑end | Next.js 15 / App Router | https://example.com |
 | DB | MariaDB 11 | internal |
 | Reverse proxy / TLS | Traefik v3 (DNS‑01 via Cloudflare) | 80 / 443 |
 

--- a/scripts/site-info.js
+++ b/scripts/site-info.js
@@ -18,8 +18,10 @@ const wpGraphql = getComposerPackage(composerLock, 'wpackagist-plugin/wp-graphql
 
 const nextPkg = readJSON(path.join(__dirname, '..', 'nextjs-site', 'package.json'));
 
+const domain = process.env.DOMAIN || 'example.com';
+
 const info = {
-  siteName: 'robertfisher.com',
+  siteName: domain,
   urls: {
     local: {
       next: 'http://localhost',
@@ -27,9 +29,9 @@ const info = {
       graphql: 'http://localhost/graphql'
     },
     production: {
-      next: 'https://robertfisher.com',
-      nextWWW: 'https://www.robertfisher.com',
-      wordpress: 'https://wp.robertfisher.com'
+      next: `https://${domain}`,
+      nextWWW: `https://www.${domain}`,
+      wordpress: `https://wp.${domain}`
     }
   },
   versions: {
@@ -43,7 +45,7 @@ const info = {
   },
   routes: {
     wordpress: {
-      production: 'wp.robertfisher.com',
+      production: `wp.${domain}`,
       local: [
         'localhost/wp',
         'localhost/graphql',
@@ -51,7 +53,7 @@ const info = {
       ]
     },
     next: {
-      production: ['robertfisher.com', 'www.robertfisher.com'],
+      production: [domain, `www.${domain}`],
       local: 'localhost'
     }
   }


### PR DESCRIPTION
## Summary
- reference `${{ secrets.DOMAIN }}` throughout the deploy workflow
- make host rules in `docker-compose.yml` configurable
- update bootstrap script and site-info utility
- generalize docs and document the required `DOMAIN` secret

## Testing
- `pnpm lint`
- `composer lint`

------
https://chatgpt.com/codex/tasks/task_e_687da0305cc483219cfdcbbc173840a7