### PR TITLE
Update Traefik docs to v2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * **WordPress** (Roots / Bedrock) — headless CMS  
 * **Next.js 15** (React 19 ready) — front‑end  
-* **Traefik 3** — reverse‑proxy + automatic Let’s Encrypt via Cloudflare  
+* **Traefik 2.11** — reverse‑proxy + automatic Let’s Encrypt via Cloudflare  
 * One `docker‑compose.yml` that runs **locally** and **on the droplet**
 
 ---

--- a/nextjs-site/README.md
+++ b/nextjs-site/README.md
@@ -5,7 +5,7 @@
 | CMS & API | WordPress (Bedrock) + WPGraphQL | https://wp.example.com |
 | Front‑end | Next.js 15 / App Router | https://example.com |
 | DB | MariaDB 11 | internal |
-| Reverse proxy / TLS | Traefik v3 (DNS‑01 via Cloudflare) | 80 / 443 |
+| Reverse proxy / TLS | Traefik v2.11 (DNS‑01 via Cloudflare) | 80 / 443 |
 
 ## Local development
 

--- a/scripts/site-info.js
+++ b/scripts/site-info.js
@@ -56,7 +56,7 @@ const info = {
       'wp-graphql': wpGraphql ? wpGraphql.version : null
     },
     nextjs: nextPkg.dependencies.next,
-    traefik: '3',
+    traefik: '2.11',
     mariadb: '11'
   },
   routes: {


### PR DESCRIPTION
## Summary
- update README notes for Traefik 2.11
- adjust Next.js README table
- report Traefik version 2.11 in site-info script

## Testing
- `pnpm lint` in `nextjs-site`
- `composer lint` in `wordpress`


------
https://chatgpt.com/codex/tasks/task_e_687ecc6b36f48321bdacc6a83695bf23