### PR TITLE
Fix Traefik ACME domains flag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,8 +81,7 @@ services:
       - "--certificatesresolvers.cf.acme.dnschallenge.provider=cloudflare"
       - "--certificatesresolvers.cf.acme.email=${LE_EMAIL:-local@example.com}"
       - "--certificatesresolvers.cf.acme.storage=/letsencrypt/acme.json"
-      - "--certificatesresolvers.cf.acme.domains[0].main=${DOMAIN:-example.com}"
-      - "--certificatesresolvers.cf.acme.domains[0].sans=*.${DOMAIN:-example.com}"
+      - "--certificatesresolvers.cf.acme.domains=${DOMAIN:-example.com},*.${DOMAIN:-example.com}"
     environment:
       CLOUDFLARE_DNS_API_TOKEN: ${CLOUDFLARE_DNS_API_TOKEN:-dev}
       LE_EMAIL: ${LE_EMAIL:-local@example.com}


### PR DESCRIPTION
## Summary
- update Traefik command in `docker-compose.yml` to use new ACME domains flag

## Testing
- `pnpm lint`
- `composer lint`


------
https://chatgpt.com/codex/tasks/task_e_687ed98ba11c8321a269dbb4d3030182