### PR TITLE
docs: emphasize DOMAIN secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ DOMAIN=example.com
 ``` |
 | **GitHub → repo → Settings → Secrets** | same vars + `DOMAIN` |
 
+**Note:** The GitHub secret `DOMAIN` **must** be set—if it is missing the deploy workflow will fail.
+
 #### Traefik `le` volume
 
 Traefik keeps Let’s Encrypt data in the named volume `le`.  That volume


### PR DESCRIPTION
## Summary
- document that the deploy workflow will fail if the `DOMAIN` GitHub secret is missing

## Testing
- `pnpm lint` within `nextjs-site`
- `composer lint` within `wordpress`


------
https://chatgpt.com/codex/tasks/task_e_687ee2df23808321b9a36d3fca0a5550