### PR TITLE
Add WordPress logs on deploy failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -239,6 +239,7 @@ jobs:
             if [ "$status" != "200" ]; then
               echo '❌ GraphQL endpoint unreachable after 2 min'
               docker compose logs traefik | tail -n 50
+              docker compose logs wordpress | tail -n 50
               exit 1
             fi
 


### PR DESCRIPTION
## Summary
- capture WordPress container logs if GraphQL check fails

## Testing
- `pnpm lint` in `nextjs-site`
- `composer lint` in `wordpress`


------
https://chatgpt.com/codex/tasks/task_e_687ee2e217548321b4b30b23231f6317