### PR TITLE
Update Node base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ─────────────────── Build stage ───────────────────
-FROM node:22-slim AS builder
+FROM node:20-slim AS builder
 WORKDIR /app
 
 ARG NEXT_PUBLIC_WPGRAPHQL_URL
@@ -17,7 +17,7 @@ COPY . .
 RUN pnpm --filter nextjs-site build
 
 # ─────────────────── Runtime stage ───────────────────
-FROM node:22-slim
+FROM node:20-slim
 WORKDIR /app
 ENV NODE_ENV=production
 

--- a/nextjs-site/Dockerfile
+++ b/nextjs-site/Dockerfile
@@ -1,5 +1,5 @@
 # ───────────── Build stage ─────────────
-FROM node:22-slim AS builder
+FROM node:20-slim AS builder
 WORKDIR /app
 
 ARG NEXT_PUBLIC_WPGRAPHQL_URL
@@ -14,7 +14,7 @@ COPY . .
 RUN pnpm build
 
 # ─────────── Runtime stage ────────────
-FROM node:22-slim
+FROM node:20-slim
 WORKDIR /app
 ENV NODE_ENV=production
 


### PR DESCRIPTION
## Summary
- use `node:20-slim` in Dockerfiles
- confirm deploy workflow uses Node 20

## Testing
- `pnpm lint` in `nextjs-site`
- `composer lint` in `wordpress`


------
https://chatgpt.com/codex/tasks/task_e_687ee2e2dc8c8321aebcf7c8da54de4b