### PR TITLE
Fix bootstrap plugin activation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -216,7 +216,8 @@ jobs:
                   --admin_password=${WP_ADMIN_PASS:-changeme} \
                   --admin_email=${WP_ADMIN_EMAIL:-you@example.com} \
                   --skip-email --allow-root &&
-              wp plugin install wp-graphql --activate --allow-root &&
+              wp plugin is-active wp-graphql --allow-root || \
+                wp plugin activate wp-graphql --allow-root &&
               wp option update permalink_structure "/%postname%/" --allow-root &&
               wp rewrite flush --hard --allow-root
             '


### PR DESCRIPTION
## Summary
- run `wp plugin activate wp-graphql` in deploy bootstrap script
- avoid errors when the plugin is already active

## Testing
- `pnpm lint`
- `composer lint`


------
https://chatgpt.com/codex/tasks/task_e_687ee2e48d8883218ef2c78063316131