### PR TITLE
Add WordPress healthcheck & streamline deploy wait

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -229,20 +229,8 @@ jobs:
             docker compose up -d --remove-orphans
             /srv/consultancy/bin/wp-bootstrap.sh
 
-            # -------- GraphQL smoke‑test (≤ 2 min) -------------------
-            echo "⏳ Waiting for WP GraphQL to answer over HTTPS…"
-            for i in {1..24}; do
-              status=$(curl -ksw '%{http_code}' -o /dev/null \
-                       "https://wp.$DOMAIN/graphql?query=%7B__typename%7D") || true
-              [ "$status" = "200" ] && { echo '✅ GraphQL OK'; break; }
-              echo " …still starting (HTTP $status), retry $i/24"; sleep 5
-            done
-            if [ "$status" != "200" ]; then
-              echo '❌ GraphQL endpoint unreachable after 2 min'
-              docker compose logs traefik | tail -n 50
-              docker compose logs wordpress | tail -n 50
-              exit 1
-            fi
+            # -------- wait for WordPress -----------------------------
+            docker compose wait wordpress
 
       # ---------- WordPress housekeeping ----------------------------
       - name: WordPress housekeeping

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,10 @@ services:
       WP_SITEURL: ${WP_SITEURL:-http://localhost:8080/wp}
     volumes:
       - uploads:/var/www/html/web/app/uploads
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost/graphql?query=%7B__typename%7D || exit 1"]
+      interval: 10s
+      retries: 30
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.wp.rule=Host(`wp.${DOMAIN:-example.com}`)"


### PR DESCRIPTION
## Summary
- add a healthcheck for the `wordpress` service in `docker-compose.yml`
- simplify readiness check in CI deploy workflow to `docker compose wait wordpress`

## Testing
- `pnpm lint`
- `composer lint`


------
https://chatgpt.com/codex/tasks/task_e_687ef0f9c458832192c6f85f3a378090