### PR TITLE
Fix GraphQL access in WP image

### DIFF
--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -38,6 +38,7 @@ COPY --from=composer /app/vendor ./vendor
 # ─── Helper MU‑plugins ─────────────────────────────────────────────
 COPY web/app/mu-plugins/wp-cli-htaccess-fix.php       web/app/mu-plugins/
 COPY web/app/mu-plugins/disable-graphql-canonical.php web/app/mu-plugins/
+COPY vendor/roots/bedrock/autoloader.php              web/app/mu-plugins/bedrock-autoloader.php
 
 # ─── keep Site‑Health green → pre‑create wp‑content/upgrade ────────
 RUN mkdir -p web/app/upgrade


### PR DESCRIPTION
## Summary
- copy the Bedrock autoloader from `vendor` during the WordPress image build

## Testing
- `pnpm lint`
- `composer lint`
- `docker compose up -d db wordpress` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_687ef0fbc4c4832197bc68298fe6ece3