### PR TITLE
Fix Bedrock autoloader copy in Dockerfile

### DIFF
--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -38,7 +38,7 @@ COPY --from=composer /app/vendor ./vendor
 # ─── Helper MU‑plugins ─────────────────────────────────────────────
 COPY web/app/mu-plugins/wp-cli-htaccess-fix.php       web/app/mu-plugins/
 COPY web/app/mu-plugins/disable-graphql-canonical.php web/app/mu-plugins/
-COPY vendor/roots/bedrock/autoloader.php              web/app/mu-plugins/bedrock-autoloader.php
+COPY web/app/mu-plugins/bedrock-autoloader.php        web/app/mu-plugins/
 
 # ─── keep Site‑Health green → pre‑create wp‑content/upgrade ────────
 RUN mkdir -p web/app/upgrade


### PR DESCRIPTION
## Summary
- fix missing Bedrock autoloader by copying the version in the repository

## Testing
- `composer lint`
- `pnpm lint`
- `docker build -t test-wordpress .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_687f07c1da28832199ba32f8609578d3