### PR TITLE
Remove docker wait command from deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,7 +231,7 @@ jobs:
             /srv/consultancy/bin/wp-bootstrap.sh
 
             # -------- wait for WordPress -----------------------------
-            docker compose wait wordpress
+            # docker compose wait wordpress
 
       # ---------- WordPress housekeeping ----------------------------
       - name: WordPress housekeeping


### PR DESCRIPTION
## Summary
- comment out `docker compose wait wordpress` to avoid hanging in deploy job

## Testing
- `pnpm lint` within `nextjs-site`
- `composer lint` within `wordpress`


------
https://chatgpt.com/codex/tasks/task_e_687f900a23d08321aedb8a54494390ae