### PR TITLE
Use WP_HOME in bootstrap

### DIFF
--- a/bin/wp-bootstrap.sh
+++ b/bin/wp-bootstrap.sh
@@ -2,8 +2,9 @@ set -eu
 
 docker compose exec wordpress bash -c '
   cd /var/www/html/web &&
+  URL=${WP_HOME:-https://wp.${DOMAIN:-example.com}} &&
   wp core is-installed --allow-root || wp core install \
-      --url=https://wp.${DOMAIN:-example.com} \
+      --url="$URL" \
       --title="Production Site" \
       --admin_user=${WP_ADMIN_USER:-admin} \
       --admin_password=${WP_ADMIN_PASS:-changeme} \


### PR DESCRIPTION
## Summary
- pull WP_HOME from `.env` when installing WP

## Testing
- `pnpm lint`
- `composer lint`


------
https://chatgpt.com/codex/tasks/task_e_687f9f45cd4c8321a3b364d842201fc5