### PR TITLE
Support 127.0.0.1 for local WP routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - "traefik.http.routers.wp.entrypoints=websecure"
       - "traefik.http.routers.wp.tls.certresolver=cf"
       - "traefik.http.services.wp.loadbalancer.server.port=80"
-      - "traefik.http.routers.wp-local.rule=Host(`localhost`) && (PathPrefix(`/wp`) || PathPrefix(`/graphql`) || Path(`/favicon.ico`))"
+      - "traefik.http.routers.wp-local.rule=(Host(`localhost`) || Host(`127.0.0.1`)) && (PathPrefix(`/wp`) || PathPrefix(`/graphql`) || Path(`/favicon.ico`))"
       - "traefik.http.routers.wp-local.entrypoints=web"
       - "traefik.http.routers.wp-local.priority=12"
     depends_on:


### PR DESCRIPTION
## Summary
- update the Traefik rule for the WordPress container to allow `127.0.0.1`

## Testing
- `pnpm lint` in `nextjs-site`
- `composer lint` in `wordpress`
- `docker compose up -d` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_687f9f4891348321bf612c96ecc32db2