### PR TITLE
Remove plugin download step

### DIFF
--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -49,12 +49,7 @@ RUN curl -sSL https://downloads.wordpress.org/theme/hello-elementor.zip \
  && unzip -q /tmp/hello.zip -d web/app/themes \
  && rm /tmp/hello.zip
 
-# ─── bake WP GraphQL plugin (latest stable) ────────────────────────
-RUN rm -rf web/app/plugins/wp-graphql && \
-    curl -sSL https://downloads.wordpress.org/plugin/wp-graphql.latest-stable.zip \
-      -o /tmp/wp-graphql.zip && \
-    unzip -qo /tmp/wp-graphql.zip -d web/app/plugins && \
-    rm /tmp/wp-graphql.zip
+# ─── WP GraphQL plugin installed via Composer ──────────────────────
 
 # ─── remove bundled Twenty* themes (core + Bedrock copy) ───────────
 RUN rm -rf web/wp/wp-content/themes/twenty* \


### PR DESCRIPTION
## Summary
- remove curl step downloading `latest-stable` WPGraphQL
- rely solely on the Composer-installed plugin

## Testing
- `composer install`
- `composer lint`
- `pnpm install`
- `pnpm lint`
- `docker compose build wordpress` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_687f9f4a96d88321962fc7df9a2ef48b