### PR TITLE
Auto-create Traefik acme.json

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -159,6 +159,14 @@ jobs:
               traefik:
                 image: traefik:v2.11            # ← pin to Traefik v2
                 restart: unless-stopped
+                init: true
+                entrypoint:
+                  - /bin/sh
+                  - -c
+                  - |
+                    touch /letsencrypt/acme.json
+                    chmod 600 /letsencrypt/acme.json
+                    exec traefik "$@"
                 command:
                   - --log.level=INFO
                   - --providers.docker=true

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cd wordpress   && composer install
 
 | Goal | One‑liner | Opens in browser |
 |------|-----------|------------------|
-| build & start | `./bin/check-traefik.sh && docker compose up --build -d` | – |
+| build & start | `./bin/check-traefik.sh && docker compose up -d` | – |
 | WP admin | – | <http://localhost:8000/wp/wp-admin> |
 | GraphQL | – | <http://localhost:8000/graphql> |
 | Next.js (container) | – | <http://localhost:3000> |
@@ -66,23 +66,10 @@ DOMAIN=example.com
 
 #### Traefik `le` volume
 
-Traefik keeps Let’s Encrypt data in the named volume `le`.  That volume
-needs an `acme.json` file with permissions `600`.
-Inspect the volume to find its path (usually
-`/var/lib/docker/volumes/<project>_le/_data`):
-
-```bash
-docker volume inspect le
-```
-
-Create the file inside that directory before starting Traefik:
-
-```bash
-touch /var/lib/docker/volumes/consulting-wp-next_le/_data/acme.json
-chmod 600 /var/lib/docker/volumes/consulting-wp-next_le/_data/acme.json
-```
-
-Run `./bin/check-traefik.sh` to verify these prerequisites before starting Traefik.
+Traefik stores Let’s Encrypt data in the `le` volume. The container automatically
+creates `/letsencrypt/acme.json` with permissions `600` when it starts.
+Run `./bin/check-traefik.sh` before starting to verify that required environment
+variables are set.
 
 ### 2.2 CI/CD flow
 

--- a/bin/check-traefik.sh
+++ b/bin/check-traefik.sh
@@ -17,22 +17,6 @@ for var in DOMAIN LE_EMAIL CLOUDFLARE_DNS_API_TOKEN; do
   fi
 done
 
-volume_path=$(docker volume inspect le --format '{{ .Mountpoint }}' 2>/dev/null || true)
-acme="$volume_path/acme.json"
-if [ -z "$volume_path" ]; then
-  echo "Error: Docker volume 'le' not found" >&2
-  missing=1
-elif [ ! -f "$acme" ]; then
-  echo "Error: $acme not found" >&2
-  missing=1
-else
-  perm=$(stat -c %a "$acme")
-  if [ "$perm" != "600" ]; then
-    echo "Error: $acme should have permissions 600 (current $perm)" >&2
-    missing=1
-  fi
-fi
-
 if [ "$missing" -eq 1 ]; then
   echo "Fix the above issues before starting Traefik." >&2
   exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,14 @@ services:
   traefik:
     image: traefik:v2.11
     restart: unless-stopped
+    init: true
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        touch /letsencrypt/acme.json
+        chmod 600 /letsencrypt/acme.json
+        exec traefik "$@"
     depends_on:
       next:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- auto-create `/letsencrypt/acme.json` in `docker-compose.yml`
- mirror these options in deploy workflow
- trim acme.json checks from `check-traefik.sh`
- clarify docs about auto prepared acme file and simpler startup command

## Testing
- `corepack enable pnpm`
- `pnpm install --frozen-lockfile` in `nextjs-site`
- `pnpm lint` in `nextjs-site`
- `composer install` in `wordpress`
- `composer lint` in `wordpress`


------
https://chatgpt.com/codex/tasks/task_e_687fbb11e8348321b247663d55e82b4c