### PR TITLE
Remove explicit acme domains flag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,7 +149,7 @@ jobs:
                 expose: [ "3000" ]
                 labels:
                   - traefik.enable=true
-                  - traefik.http.routers.next.rule=Host(`${DOMAIN}`) || Host(`www.${DOMAIN}`)
+                  - traefik.http.routers.next.rule=HostRegexp(`{subdomain:[a-zA-Z0-9-]+}.${DOMAIN}`, `${DOMAIN}`)
                   - traefik.http.routers.next.entrypoints=websecure
                   - traefik.http.routers.next.tls.certresolver=cf
                   - traefik.http.services.next.loadbalancer.server.port=3000
@@ -177,7 +177,6 @@ jobs:
                   - --certificatesresolvers.cf.acme.dnschallenge.provider=cloudflare
                   - --certificatesresolvers.cf.acme.email=${LE_EMAIL}
                   - --certificatesresolvers.cf.acme.storage=/letsencrypt/acme.json
-                  - --certificatesresolvers.cf.acme.domains=${DOMAIN},*.${DOMAIN}
                 environment:
                   CLOUDFLARE_DNS_API_TOKEN: ${CLOUDFLARE_DNS_API_TOKEN}
                   LE_EMAIL: ${LE_EMAIL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       retries: 30
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.next.rule=Host(`${DOMAIN:-example.com}`) || Host(`www.${DOMAIN:-example.com}`)"
+      - "traefik.http.routers.next.rule=HostRegexp(`{subdomain:[a-zA-Z0-9-]+}.${DOMAIN:-example.com}`, `${DOMAIN:-example.com}`)"
       - "traefik.http.routers.next.entrypoints=websecure"
       - "traefik.http.routers.next.tls.certresolver=cf"
       - "traefik.http.services.next.loadbalancer.server.port=3000"
@@ -103,7 +103,6 @@ services:
       - "--certificatesresolvers.cf.acme.dnschallenge.provider=cloudflare"
       - "--certificatesresolvers.cf.acme.email=${LE_EMAIL:-local@example.com}"
       - "--certificatesresolvers.cf.acme.storage=/letsencrypt/acme.json"
-      - "--certificatesresolvers.cf.acme.domains=${DOMAIN:-example.com},*.${DOMAIN:-example.com}"
     environment:
       CLOUDFLARE_DNS_API_TOKEN: ${CLOUDFLARE_DNS_API_TOKEN:-dev}
       LE_EMAIL: ${LE_EMAIL:-local@example.com}


### PR DESCRIPTION
## Summary
- drop `--certificatesresolvers.cf.acme.domains` usage
- rely on router rules for `${DOMAIN}` and `*.${DOMAIN}` via `HostRegexp`

## Testing
- `pnpm lint`
- `composer lint`
- `docker compose up -d` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_687fd0c514a08321854098edcd20ddeb