### PR TITLE
Apply doc fixes and env improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,12 @@ DOMAIN=example.com
 # ─────── MariaDB root password (local & CI) ────────────────────────────
 MYSQL_ROOT_PASSWORD=local-db-password
 
+# ─────── WordPress admin override (optional) ───────
+# Defaults: admin/changeme/you@example.com
+# WP_ADMIN_USER=admin
+# WP_ADMIN_PASS=changeme
+# WP_ADMIN_EMAIL=you@example.com
+
 # ─────── WordPress GraphQL endpoint the front‑end must call ────────────
 # In dev this is proxied by Traefik on port 8000.
 NEXT_PUBLIC_WPGRAPHQL_URL=http://localhost:8000/graphql

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## 1 Local workflow
 
-1. Copy `.env.example` → `.env` and `stack.env.example` → `stack.env`, then fill in the placeholder values.
+1. Copy `.env.example` → `.env` and `stack.env.example` → `stack.env`, then fill in the placeholder values. Optionally set `WP_ADMIN_USER`, `WP_ADMIN_PASS` and `WP_ADMIN_EMAIL` in `.env` to override the default admin credentials (`admin` / `changeme` / `you@example.com`).
 2. Copy `nextjs-site/.env.example` → `nextjs-site/.env.local` before running `pnpm dev`.
 3. Install dependencies **before** running Docker:
 

--- a/bin/check-traefik.sh
+++ b/bin/check-traefik.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Load variables from .env if present
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/nextjs-site/README.md
+++ b/nextjs-site/README.md
@@ -20,3 +20,7 @@ echo "MYSQL_ROOT_PASSWORD=secret" > .env
 docker compose up --build -d          # builds WP + Next
 open http://localhost:8000/wp/wp-admin/   # install WordPress
 open http://localhost:8000               # Next.js
+```
+
+Run ./bin/wp-bootstrap.sh after the containers start to install WordPress
+automatically and activate WPGraphQL.


### PR DESCRIPTION
## Summary
- close fenced block in `nextjs-site/README.md`
- mention optional WP admin variables in the main docs
- list the variables in `.env.example`
- tighten `check-traefik.sh` error checking

## Testing
- `pnpm lint`
- `composer lint`


------
https://chatgpt.com/codex/tasks/task_e_687fd7489f308321a4e7c173a32b2275