### PR TITLE
Add Traefik prerequisites check in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -232,6 +232,39 @@ jobs:
             BOOT
             chmod +x /srv/consultancy/bin/wp-bootstrap.sh
 
+            # -------- traefik checker --------------------------------
+            cat > /srv/consultancy/bin/check-traefik.sh <<'CHECK'
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            # Load variables from .env if present
+            REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+            if [ -f "$REPO_ROOT/.env" ]; then
+              set -a
+              . "$REPO_ROOT/.env"
+              set +a
+            fi
+
+            missing=0
+            for var in DOMAIN LE_EMAIL CLOUDFLARE_DNS_API_TOKEN; do
+              if [ -z "${!var:-}" ]; then
+                echo "Error: $var is not set" >&2
+                missing=1
+              fi
+            done
+
+            if [ "$missing" -eq 1 ]; then
+              echo "Fix the above issues before starting Traefik." >&2
+              exit 1
+            fi
+
+            echo "Traefik prerequisites satisfied."
+            CHECK
+            chmod +x /srv/consultancy/bin/check-traefik.sh
+
+            /srv/consultancy/bin/check-traefik.sh
+
+
             # -------- pull, start, bootstrap -------------------------
             docker compose pull
             docker compose up -d --remove-orphans


### PR DESCRIPTION
## Summary
- add `check-traefik.sh` into deploy workflow
- run the script to verify environment variables before starting containers

## Testing
- `pnpm lint`
- `composer lint`


------
https://chatgpt.com/codex/tasks/task_e_6880f5220438832186eb29496353c232