### PR TITLE
Update README troubleshooting for ACME rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ variables are set.
 * `docker compose logs traefik`
 * check permissions of `acme.json` (should be `600`)
 * ensure required environment variables (`LE_EMAIL`, `CLOUDFLARE_DNS_API_TOKEN`, `MYSQL_ROOT_PASSWORD`) are set
+* Cloudflare error **526** can mean that Traefik hit the Let's Encrypt ACME rate limit. Check `docker compose logs traefik` for messages like `429 :: POST` and wait until the rate-limit window expires.
 
 ## 3 Site info
 


### PR DESCRIPTION
## Summary
- expand troubleshooting tips about Cloudflare error 526 and ACME rate limits

## Testing
- `pnpm lint`
- `composer lint`


------
https://chatgpt.com/codex/tasks/task_e_6880fe08c8088321ad258c87edc0338e