### PR TITLE
Refactor check-traefik step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -233,33 +233,9 @@ jobs:
             chmod +x /srv/consultancy/bin/wp-bootstrap.sh
 
             # -------- traefik checker --------------------------------
-            cat > /srv/consultancy/bin/check-traefik.sh <<'CHECK'
-            #!/usr/bin/env bash
-            set -euo pipefail
-
-            # Load variables from .env if present
-            REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-            if [ -f "$REPO_ROOT/.env" ]; then
-              set -a
-              . "$REPO_ROOT/.env"
-              set +a
-            fi
-
-            missing=0
-            for var in DOMAIN LE_EMAIL CLOUDFLARE_DNS_API_TOKEN; do
-              if [ -z "${!var:-}" ]; then
-                echo "Error: $var is not set" >&2
-                missing=1
-              fi
-            done
-
-            if [ "$missing" -eq 1 ]; then
-              echo "Fix the above issues before starting Traefik." >&2
-              exit 1
-            fi
-
-            echo "Traefik prerequisites satisfied."
-            CHECK
+            cat <<'EOF' > /srv/consultancy/bin/check-traefik.sh
+$(sed 's/^/            /' bin/check-traefik.sh)
+            EOF
             chmod +x /srv/consultancy/bin/check-traefik.sh
 
             /srv/consultancy/bin/check-traefik.sh


### PR DESCRIPTION
## Summary
- pipe `bin/check-traefik.sh` into ssh workflow instead of inlining script

## Testing
- `pnpm lint` in `nextjs-site`
- `composer lint` in `wordpress`


------
https://chatgpt.com/codex/tasks/task_e_6880fe094df48321aaf095fe17bbf53b