### PR TITLE
Fix GraphQL endpoint path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,4 +16,4 @@ MYSQL_ROOT_PASSWORD=local-db-password
 
 # ─────── WordPress GraphQL endpoint the front‑end must call ────────────
 # In dev this is proxied by Traefik on port 8000.
-NEXT_PUBLIC_WPGRAPHQL_URL=http://localhost:8000/graphql
+NEXT_PUBLIC_WPGRAPHQL_URL=http://localhost:8000/wp/graphql

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           [ -z "$DOMAIN" ] && { echo "❌ DOMAIN secret is unset"; exit 1; }
           docker build \
-            --build-arg NEXT_PUBLIC_WPGRAPHQL_URL=https://wp.$DOMAIN/graphql \
+            --build-arg NEXT_PUBLIC_WPGRAPHQL_URL=https://wp.$DOMAIN/wp/graphql \
             --build-arg NEXT_SKIP_BUILD_STATIC_GENERATION=true \
             -t ghcr.io/${{ github.repository }}/next:${{ github.sha }} nextjs-site
           docker push ghcr.io/${{ github.repository }}/next:${{ github.sha }}
@@ -163,7 +163,7 @@ jobs:
                 image: ghcr.io/${{ github.repository }}/next:${{ github.sha }}
                 restart: unless-stopped
                 environment:
-                  NEXT_PUBLIC_WPGRAPHQL_URL: https://wp.${DOMAIN}/graphql
+                  NEXT_PUBLIC_WPGRAPHQL_URL: https://wp.${DOMAIN}/wp/graphql
                 expose:
                   - "3000"
                 labels:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cd wordpress   && composer install
 |------|-----------|------------------|
 | build & start | `./bin/check-traefik.sh && docker compose up -d` | – |
 | WP admin | – | <http://localhost:8000/wp/wp-admin> |
-| GraphQL | – | <http://localhost:8000/graphql> |
+| GraphQL | – | <http://localhost:8000/wp/graphql> |
 | Next.js (container) | – | <http://localhost:3000> |
 | ultrafast React dev (Turbopack) | `cd nextjs-site && pnpm dev` | <http://localhost:3000> |
 | stop stack | `docker compose down` | – |
@@ -38,7 +38,7 @@ docker compose up -d            # fresh DB, run installer
 
 * After `docker compose up`, run `./bin/wp-bootstrap.sh` to install WordPress using `DOMAIN` from `.env`, activate **WP GraphQL** and set permalinks.
 * `https://localhost:8000/wp/wp-admin` shows the login screen
-* `http://localhost:8000/graphql` returns `{"errors":[{"message":"Must provide query string"}]}`
+* `http://localhost:8000/wp/graphql` returns `{"errors":[{"message":"Must provide query string"}]}`
   (no redirect to `/graphql/`; if you see a 301, flush permalinks and verify
   `web/app/mu-plugins/disable-graphql-canonical.php` is present)
 * `http://localhost:3000` renders the Next.js front‑end (or use Turbopack on :3000).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,13 +51,13 @@ services:
     build:
       context: ./nextjs-site
       args:
-        NEXT_PUBLIC_WPGRAPHQL_URL: http://wordpress/graphql
+        NEXT_PUBLIC_WPGRAPHQL_URL: http://wordpress/wp/graphql
     restart: unless-stopped
     expose: ["3000"]
     ports:
       - "3000:3000"
     environment:
-      NEXT_PUBLIC_WPGRAPHQL_URL: http://wordpress/graphql
+      NEXT_PUBLIC_WPGRAPHQL_URL: http://wordpress/wp/graphql
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:3000 || exit 1"]
       interval: 10s

--- a/nextjs-site/.env.example
+++ b/nextjs-site/.env.example
@@ -1,3 +1,3 @@
-NEXT_PUBLIC_WPGRAPHQL_URL=http://localhost:8000/graphql
+NEXT_PUBLIC_WPGRAPHQL_URL=http://localhost:8000/wp/graphql
 # Disable static generation during Docker build
 NEXT_SKIP_BUILD_STATIC_GENERATION=true


### PR DESCRIPTION
## Summary
- update GraphQL endpoint to `/wp/graphql` in compose file and deploy workflow
- adjust example env files
- update docs

## Testing
- `pnpm lint`
- `composer lint`


------
https://chatgpt.com/codex/tasks/task_e_688122e019a483218dfae9159321b948